### PR TITLE
Display amount of downloads/licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 - More statistics, e.g. to see how many people visit a marketplace page.
 - Sort marketplace results randomly.
 - Send an email if someone grants you a license.
+- Display amount of downloads/licenses sold for Add-Ons


### PR DESCRIPTION
Other marketplaces show amount of downloads too:

https://wordpress.org/plugins/wordpress-seo/ (Active installations)
https://octobercms.com/plugins ([xxx] projects)
https://www.opencart.com/index.php?route=marketplace/extension/info&extension_id=30170 ([xxx] sales)
https://codecanyon.net/search/concrete5?as=0&referrer=homepage&utf8=%E2%9C%93 ([xxx] Sales)